### PR TITLE
read_only, mysql deployment cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
 
     - name: test read_only
       run: |
+        ~/sandboxes/57/use_all "select @@global.read_only"
         ro="$(mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@global.read_only")"
         if [ "$ro" != "0" ] ; then
           echo "expected read_only=0 on master, got $ro"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,18 @@ jobs:
       run: |
         mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@report_port" | grep -q 10571
 
+    - name: test read_only
+        ro="$(mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@global.read_only")"
+        if [ "$ro" != "0" ] ; then
+          echo "expected read_only=0 on master, got $ro"
+          exit 1
+        fi
+        ro="$(mysql -uci -pci -h 127.0.0.1 --port 10572 -s -s -e "select @@global.read_only")"
+        if [ "$ro" != "1" ] ; then
+          echo "expected read_only=1 on replica, got $ro"
+          exit 1
+        fi
+
     - name: test haproxy routing to mysql master
       run: |
         mysql -uci -pci -h 127.0.0.1 --port 13306 -s -s -e "select @@report_port" | grep -q 10571

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
         mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@report_port" | grep -q 10571
 
     - name: test read_only
+      run: |
         ro="$(mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@global.read_only")"
         if [ "$ro" != "0" ] ; then
           echo "expected read_only=0 on master, got $ro"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
 
     - name: test read_only
       run: |
-        ~/sandboxes/57/use_all "select @@global.read_only"
         ro="$(mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@global.read_only")"
         if [ "$ro" != "0" ] ; then
           echo "expected read_only=0 on master, got $ro"
@@ -133,6 +132,7 @@ jobs:
           echo "expected read_only=1 on replica, got $ro"
           exit 1
         fi
+        echo "read_only" validated
 
     - name: test haproxy routing to mysql master
       run: |

--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -2,6 +2,10 @@
 
 [ -f bin/linux/dbdeployer.gz ] && (cd bin/linux ; gunzip dbdeployer.gz)
 
+~/sandboxes/57/stop_all
+dbdeployer delete 57
+sudo rm -rf ~/sandboxes/57
+
 mkdir -p ~/opt/mysql
 bin/linux/dbdeployer unpack mysql-tarballs/mysql-5.7.26.tar.xz
 bin/linux/dbdeployer deploy replication 5.7.26 \
@@ -17,3 +21,5 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --my-cnf-options="log_slave_updates" \
   --my-cnf-options="performance_schema=0" \
   --my-cnf-options="innodb_buffer_pool_size=32M"
+  --my-cnf-options="read_only=1"
+~/sandboxes/57/m -e "set global read_only=0"

--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -20,6 +20,6 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --my-cnf-options="log_bin" \
   --my-cnf-options="log_slave_updates" \
   --my-cnf-options="performance_schema=0" \
-  --my-cnf-options="innodb_buffer_pool_size=32M"
+  --my-cnf-options="innodb_buffer_pool_size=32M" \
   --my-cnf-options="read_only=1"
 ~/sandboxes/57/m -e "set global read_only=0"

--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -2,9 +2,9 @@
 
 [ -f bin/linux/dbdeployer.gz ] && (cd bin/linux ; gunzip dbdeployer.gz)
 
-~/sandboxes/57/stop_all
-dbdeployer delete 57
-sudo rm -rf ~/sandboxes/57
+~/sandboxes/57/stop_all || :
+dbdeployer delete 57 || :
+sudo rm -rf ~/sandboxes/57 || :
 
 mkdir -p ~/opt/mysql
 bin/linux/dbdeployer unpack mysql-tarballs/mysql-5.7.26.tar.xz


### PR DESCRIPTION
A couple updates:

- Topology is `read_only` except master
- When deploying MySQL, first attempt to remove existing deployment, gracefully or forcibly.