### PR TITLE
change of mysql ports and sandbox path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,17 +85,17 @@ jobs:
     - name: populate consul kv
       run: |
         consul kv put "mysql/master/ci/hostname" "127.0.0.1"
-        consul kv put "mysql/master/ci/port" "10571"
+        consul kv put "mysql/master/ci/port" "10111"
 
     - name: test consul kv
       run: |
-        if consul kv get "mysql/master/ci/port" | grep -q 10571 ; then
+        if consul kv get "mysql/master/ci/port" | grep -q 10111 ; then
           echo "Validated KV write+read"
         else
           echo "Failed validating consul KV"
           exit 1
         fi
-        if curl -s http://127.0.0.1:8500/v1/kv/mysql/master/ci/port | jq -r '.[].Value' | base64 --decode | grep -q 10571 ; then
+        if curl -s http://127.0.0.1:8500/v1/kv/mysql/master/ci/port | jq -r '.[].Value' | base64 --decode | grep -q 10111 ; then
           echo "Validated KV read via HTTP API"
         else
           echo "Failed validating consul KV via HTTP API"
@@ -105,7 +105,7 @@ jobs:
     - name: test consul-template template
       run: |
         cat /etc/haproxy/haproxy.cfg
-        grep 10571 /etc/haproxy/haproxy.cfg || (sudo journalctl -u consul-template.service ; exit 1)
+        grep 10111 /etc/haproxy/haproxy.cfg || (sudo journalctl -u consul-template.service ; exit 1)
 
     - name: unwrap dbdeployer
       run: |
@@ -118,16 +118,16 @@ jobs:
 
     - name: test mysql master
       run: |
-        mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@report_port" | grep -q 10571
+        mysql -uci -pci -h 127.0.0.1 --port 10111 -s -s -e "select @@report_port" | grep -q 10111
 
     - name: test read_only
       run: |
-        ro="$(mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@global.read_only")"
+        ro="$(mysql -uci -pci -h 127.0.0.1 --port 10111 -s -s -e "select @@global.read_only")"
         if [ "$ro" != "0" ] ; then
           echo "expected read_only=0 on master, got $ro"
           exit 1
         fi
-        ro="$(mysql -uci -pci -h 127.0.0.1 --port 10572 -s -s -e "select @@global.read_only")"
+        ro="$(mysql -uci -pci -h 127.0.0.1 --port 10112 -s -s -e "select @@global.read_only")"
         if [ "$ro" != "1" ] ; then
           echo "expected read_only=1 on replica, got $ro"
           exit 1
@@ -136,7 +136,7 @@ jobs:
 
     - name: test haproxy routing to mysql master
       run: |
-        mysql -uci -pci -h 127.0.0.1 --port 13306 -s -s -e "select @@report_port" | grep -q 10571
+        mysql -uci -pci -h 127.0.0.1 --port 13306 -s -s -e "select @@report_port" | grep -q 10111
 
 
     - name: deploy mysql heartbeat

--- a/script/deploy-heartbeat
+++ b/script/deploy-heartbeat
@@ -3,4 +3,4 @@
 sudo cp bin/linux/heartbeat.sh /usr/local/bin/heartbeat
 sudo cp files/etc/systemd/mysql-heartbeat.service /etc/systemd/system/
 
-mysql -uci -pci -h 127.0.0.1 --port 10571 test < sql/heartbeat.sql
+mysql -uci -pci -h 127.0.0.1 --port 10111 test < sql/heartbeat.sql

--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -2,15 +2,15 @@
 
 [ -f bin/linux/dbdeployer.gz ] && (cd bin/linux ; gunzip dbdeployer.gz)
 
-~/sandboxes/57/stop_all || :
-dbdeployer delete 57 || :
-sudo rm -rf ~/sandboxes/57 || :
+~/sandboxes/ci/stop_all || :
+dbdeployer delete ci || :
+sudo rm -rf ~/sandboxes/ci || :
 
 mkdir -p ~/opt/mysql
 bin/linux/dbdeployer unpack mysql-tarballs/mysql-5.7.26.tar.xz
 bin/linux/dbdeployer deploy replication 5.7.26 \
-  --sandbox-directory="57" \
-  --base-port=10570 \
+  --sandbox-directory="ci" \
+  --base-port=10110 \
   -n 4 \
   --gtid \
   --repl-crash-safe \
@@ -22,4 +22,4 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --my-cnf-options="performance_schema=0" \
   --my-cnf-options="innodb_buffer_pool_size=32M" \
   --my-cnf-options="read_only=1"
-~/sandboxes/57/m -e "set global read_only=0"
+~/sandboxes/ci/m -e "set global read_only=0"

--- a/script/docker-entry
+++ b/script/docker-entry
@@ -7,12 +7,12 @@ script/run-consul-template
 
 sleep 3
 consul kv put "mysql/master/ci/hostname" "127.0.0.1"
-consul kv put "mysql/master/ci/port" "10571"
+consul kv put "mysql/master/ci/port" "10111"
 sleep 3
 
 PATH=$PATH:~/opt/mysql/5.7.26/bin/
 
-mysql -uci -pci -h 127.0.0.1 --port 10571 -s -s -e "select @@report_port"
+mysql -uci -pci -h 127.0.0.1 --port 10111 -s -s -e "select @@report_port"
 mysql -uci -pci -h 127.0.0.1 --port 13306 -s -s -e "select @@report_port"
 
 /bin/bash


### PR DESCRIPTION
Initial work to abstract away the MySQL version (which is still 5.7):

- sandboxes path is `ci` instead of `57`
- MySQL ports are `1011[1234]`