### PR TITLE
heartbeat table creation postponed to run-heartbeat

### DIFF
--- a/script/deploy-heartbeat
+++ b/script/deploy-heartbeat
@@ -2,5 +2,3 @@
 
 sudo cp bin/linux/heartbeat.sh /usr/local/bin/heartbeat
 sudo cp files/etc/systemd/mysql-heartbeat.service /etc/systemd/system/
-
-mysql -uci -pci -h 127.0.0.1 --port 10111 test < sql/heartbeat.sql

--- a/script/run-heartbeat
+++ b/script/run-heartbeat
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+mysql -uci -pci -h 127.0.0.1 --port 10111 test < sql/heartbeat.sql
+
 sudo systemctl start mysql-heartbeat


### PR DESCRIPTION
Because for some uses of this environment, `mysql` may not be available at time of `script/deploy-heartbeat`