### PR TITLE
heartbeat uses its own, non-super user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update -q -y # cache
-RUN apt-get install -y sudo haproxy python mysql-client libaio1 libnuma1 lsof net-tools vim less jq curl # cache
+RUN apt-get install -y sudo haproxy python mysql-client libaio1 libnuma1 lsof net-tools less jq curl # cache
 
 COPY . .
 

--- a/bin/linux/heartbeat.sh
+++ b/bin/linux/heartbeat.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 while sleep 0.5 ; do
-  mysql -uci -pci -h 127.0.0.1 --port 13306 -s -s -e "
+  mysql -uheartbeat -pheartbeat -h 127.0.0.1 --port 13306 -s -s -e "
     replace into test.heartbeat (id, ts) values (1, now(6))
   " || :
 done

--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -15,6 +15,7 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --gtid \
   --repl-crash-safe \
   --pre-grants-sql="grant all on *.* to ci@'%' identified by 'ci'" \
+  --pre-grants-sql="grant all on test.* to heartbeat@'%' identified by 'heartbeat'" \
   --my-cnf-options="report_host=127.0.0.1" \
   --my-cnf-options="bind_address=0.0.0.0" \
   --my-cnf-options="log_bin" \

--- a/script/run-heartbeat
+++ b/script/run-heartbeat
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-mysql -uci -pci -h 127.0.0.1 --port 10111 test < sql/heartbeat.sql
+mysql -uheartbeat -pheartbeat -h 127.0.0.1 --port 10111 test < sql/heartbeat.sql
 
 sudo systemctl start mysql-heartbeat


### PR DESCRIPTION
This avoids errant transactions on `graceful-master-takeover`