### PR TITLE
Replication: forcing short master heartbeat

### DIFF
--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -22,5 +22,6 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --my-cnf-options="log_slave_updates" \
   --my-cnf-options="performance_schema=0" \
   --my-cnf-options="innodb_buffer_pool_size=32M" \
+  --my-cnf-options="slave_net_timeout=2" \
   --my-cnf-options="read_only=1"
 ~/sandboxes/ci/m -e "set global read_only=0"


### PR DESCRIPTION
Setting `slave_net_timeout=2` so that `CHANGE MASTER TO...` implicitly uses a `1sec` master heartbeat interval.