### PR TITLE
Dockerfile: using a WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:18.04
 RUN apt-get update -q -y # cache
 RUN apt-get install -y sudo haproxy python mysql-client libaio1 libnuma1 lsof net-tools less jq curl # cache
 
+RUN mkdir /orchestrator-ci-env
+WORKDIR /orchestrator-ci-env
 COPY . .
 
 RUN cp bin/linux/systemctl.py /usr/bin/systemctl


### PR DESCRIPTION
Moving `WORKDIR` out of `/`