### PR TITLE
using 'service restart' to ensure freshness

### DIFF
--- a/script/run-consul
+++ b/script/run-consul
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo systemctl start consul
+sudo systemctl restart consul

--- a/script/run-consul-template
+++ b/script/run-consul-template
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo systemctl start consul-template
+sudo systemctl restart consul-template

--- a/script/run-haproxy
+++ b/script/run-haproxy
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo /etc/init.d/haproxy start
+sudo /etc/init.d/haproxy restart

--- a/script/run-heartbeat
+++ b/script/run-heartbeat
@@ -2,4 +2,4 @@
 
 mysql -uheartbeat -pheartbeat -h 127.0.0.1 --port 10111 test < sql/heartbeat.sql
 
-sudo systemctl start mysql-heartbeat
+sudo systemctl restart mysql-heartbeat


### PR DESCRIPTION
so that recurring calls to `docker-entry` will refresh all services