### PR TITLE
Manually update consul once replication redeployed

### DIFF
--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -29,3 +29,7 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --my-cnf-options="read_only=1" \
   --use-template=init_slaves_template:/etc/dbdeployer/init-replicas.tmpl
 ~/sandboxes/ci/m -e "set global read_only=0"
+
+consul kv put "mysql/master/ci/hostname" "127.0.0.1"
+consul kv put "mysql/master/ci/port" "10111"
+sleep 2

--- a/script/docker-entry
+++ b/script/docker-entry
@@ -1,15 +1,10 @@
 #!/bin/bash
 
+script/run-consul
 script/deploy-replication
 script/run-haproxy
-script/run-consul
 script/run-consul-template
 script/run-heartbeat
-
-sleep 3
-consul kv put "mysql/master/ci/hostname" "127.0.0.1"
-consul kv put "mysql/master/ci/port" "10111"
-sleep 3
 
 PATH=$PATH:~/opt/mysql/5.7.26/bin/
 


### PR DESCRIPTION
Useful for `orchestrator`'s system tests, which need a quick response and without waiting for `orchestrator` to submit KV stores