### PR TITLE
load semi-sync plugin on mysql startup

### DIFF
--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -26,6 +26,8 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --my-cnf-options="innodb_buffer_pool_size=32M" \
   --my-cnf-options="slave_net_timeout=2" \
   --my-cnf-options="read_only=1" \
+  --my-cnf-options="plugin-load-add=semisync_master.so" \
+  --my-cnf-options="plugin-load-add=semisync_slave.so" \
   --change-master-options="MASTER_CONNECT_RETRY=1" \
   --change-master-options="MASTER_RETRY_COUNT=3600" \
   --change-master-options="MASTER_HEARTBEAT_PERIOD=1"


### PR DESCRIPTION
loading `semisync_master.so` and `semisync_slave.so` on startup, though not enabling semi-sync replication.