### PR TITLE
support custom hostname

### DIFF
--- a/script/deploy-replication
+++ b/script/deploy-replication
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+REPORT_HOSTNAME=${1:-127.0.0.1}
+
 [ -f bin/linux/dbdeployer.gz ] && (cd bin/linux ; gunzip dbdeployer.gz)
 
 sudo mkdir -p /etc/dbdeployer
@@ -18,7 +20,7 @@ bin/linux/dbdeployer deploy replication 5.7.26 \
   --repl-crash-safe \
   --pre-grants-sql="grant all on *.* to ci@'%' identified by 'ci'" \
   --pre-grants-sql="grant all on test.* to heartbeat@'%' identified by 'heartbeat'" \
-  --my-cnf-options="report_host=127.0.0.1" \
+  --my-cnf-options="report_host=$REPORT_HOSTNAME" \
   --my-cnf-options="bind_address=0.0.0.0" \
   --my-cnf-options="log_bin" \
   --my-cnf-options="log_slave_updates" \

--- a/script/dock
+++ b/script/dock
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+REPORT_HOSTNAME=${1:-127.0.0.1}
+
 docker build . -f Dockerfile -t "orchestrator-ci-env" &&
   docker run --rm -it \
     -p 13306:13306 \
@@ -8,4 +10,5 @@ docker build . -f Dockerfile -t "orchestrator-ci-env" &&
     -p 10113:10113 \
     -p 10114:10114 \
     -p 8500:8500 \
+    -e "REPORT_HOSTNAME=$REPORT_HOSTNAME" \
     "orchestrator-ci-env:latest"

--- a/script/docker-entry
+++ b/script/docker-entry
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+REPORT_HOSTNAME=${REPORT_HOSTNAME:-127.0.0.1}
+
 script/run-consul
-script/deploy-replication
+script/deploy-replication "$REPORT_HOSTNAME"
 script/run-haproxy
 script/run-consul-template
 script/run-heartbeat


### PR DESCRIPTION
`script/dock` accepts an optional argument, the `report_host` to be used by MySQL. By default, this is `127.0.0.1`. 

Use case: when accessing `orchestrator-ci-env` from yet another docker image, running e.g. `script dock 172.17.0.1` (assuming `172.17.0.1` is the external IP for the docker image) can expose those ports. 